### PR TITLE
docs: detail macOS system audio capture

### DIFF
--- a/docs/mac_audio_dump.md
+++ b/docs/mac_audio_dump.md
@@ -1,0 +1,28 @@
+# macOS System Audio Capture with `SystemAudioDump`
+
+Glass uses a small native helper, [`SystemAudioDump`](../src/ui/assets/SystemAudioDump), to stream macOS system audio into the Speech‑to‑Text (STT) pipeline. The helper taps the CoreAudio output device and writes raw PCM data to `stdout`, which the STT service ingests and forwards to the "Them" transcription session.
+
+## Launch sequence
+
+1. **Renderer request** – Starting capture in the UI triggers the IPC method `listen:startMacosSystemAudio`.
+2. **Service preparation** – The [`SttService`](../src/features/listen/stt/sttService.js) kills any lingering helpers via `pkill -f SystemAudioDump` and resolves the path to the bundled binary at [`src/ui/assets/SystemAudioDump`](../src/ui/assets/SystemAudioDump) (or the unpacked equivalent in production).
+3. **Spawning** – The helper is spawned with `stdio` wired so that the service can read PCM bytes from `stdout` and log diagnostics from `stderr`.
+
+## Data flow
+
+- The helper emits 24 kHz stereo, 16‑bit PCM. The service buffers this stream into 100 ms (`CHUNK_SIZE = 24000 * 2 bytes * 2 channels * 0.1s`) chunks.
+- Each chunk is converted to mono by discarding the right channel, then base64‑encoded.
+- The encoded audio is forwarded both to the renderer (`system-audio-data`) and to the active "Them" STT WebSocket session. Provider‑specific payloads are constructed as needed (e.g., Gemini expects `{ audio: { data, mimeType } }`, Deepgram receives raw buffers).
+
+## Lifecycle management
+
+- `stderr` output from `SystemAudioDump` is logged for troubleshooting.
+- When the helper exits or errors, the service clears its reference and stops sending audio.
+- Calling `stopMacOSAudioCapture` sends a `SIGTERM` to the helper, ensuring a clean shutdown.
+
+## Integration notes
+
+- On macOS, screen capture is obtained separately via `getDisplayMedia`; system audio never travels through the browser APIs.
+- Windows relies on `getDisplayMedia({ audio: true })` for loopback capture, while Linux currently disables system audio capture.
+
+[`SystemAudioDump`](../src/ui/assets/SystemAudioDump) enables reliable separation of microphone and system audio on macOS, letting Glass transcribe remote voices without echoing the user's own microphone input.

--- a/docs/stt.md
+++ b/docs/stt.md
@@ -14,27 +14,32 @@ flowchart LR
 ```
 
 ## Session Management
+
 - A keep-alive ping is scheduled every minute and sessions are automatically renewed every 20 minutes to avoid provider timeouts.
 - When the sessions are renewed, the old and new sockets overlap briefly to prevent missing packets.
 - Completion buffers and debounced timers aggregate partial transcripts before sending final results to the UI.
 
 ## Noise Filtering and Turn Detection
+
 - Whisper transcripts are filtered for noise markers (e.g., `"[BLANK_AUDIO]"`, `"[NOISE]"`) so only meaningful speech is emitted.
 - Gemini and Deepgram interim results are likewise screened for `<noise>` tokens or empty text before being added to the buffers.
 - Providers like OpenAI enable server-side voice activity detection to better detect speaker turns.
 - The capture layer drops PCM frames whose RMS falls below an `isVoiceActive` threshold so pure background noise is never sent to the STT sessions, saving tokens.
 
 ## Audio Capture and Separation
-- For macOS the service spawns a `SystemAudioDump` helper to capture system audio. Captured chunks are converted from stereo to mono before being base64 encoded and forwarded to the "Them" session.
+
+- For macOS the service spawns a [`SystemAudioDump` helper](./mac_audio_dump.md) to capture system audio. Captured chunks are converted from stereo to mono before being base64 encoded and forwarded to the "Them" session.
 - Microphone audio is processed separately through the "Me" session, keeping the two speakers distinct.
 
 ## Acoustic Echo Suppression (AES)
+
 The STT pipeline can optionally load a WebAssembly **AES** module (`src/ui/listen/audioCore/aec.js`) to remove playback from the microphone feed. The module subtracts the system audio stream from the live microphone PCM before the cleaned data is passed to `mySttSession`, preventing remote voices from being retranscribed.
 
 ## Sound Enhancements
+
 - OpenAI's realtime STT session is configured with `input_audio_noise_reduction: { type: 'near_field' }` to suppress background noise and with server VAD parameters for accurate turn detection.
 - Additional filtering in the service removes very short or blank utterances to reduce false positives.
 
 ## Supported Providers
-The factory module can initialize STT sessions for multiple providers (OpenAI, Gemini, Deepgram, Whisper, Anthropic placeholder). Each provider receives callbacks for message handling and error reporting, but all follow the same send/close interface so the service can swap providers transparently.
 
+The factory module can initialize STT sessions for multiple providers (OpenAI, Gemini, Deepgram, Whisper, Anthropic placeholder). Each provider receives callbacks for message handling and error reporting, but all follow the same send/close interface so the service can swap providers transparently.


### PR DESCRIPTION
## Summary
- document SystemAudioDump helper and macOS system audio capture flow
- link SystemAudioDump references to binary and STT service docs

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_68bba426d92c8329903b960d1959e350